### PR TITLE
Events must be an array

### DIFF
--- a/app/models/reviewership.rb
+++ b/app/models/reviewership.rb
@@ -8,7 +8,7 @@ class Reviewership < ActiveRecord::Base
     hook_url = Rails.application.routes.url_helpers.url_for controller: "github_web_hook", action: "create", host: ENV['GITHUB_WEBHOOK_HOST']
     unless user.github.hooks(repo.name).find { |hook| hook.url == hook_url }
       config = { url: hook_url, content_type: :json, secret: ENV['GITHUB_WEBHOOK_SECRET'.freeze] }
-      user.github.create_hook(repo.name, "web", config, { events: "*" })
+      user.github.create_hook(repo.name, "web", config, { events: ["*"] })
     end
   end
 end


### PR DESCRIPTION
I was getting:  `Invalid request. For 'properties/events', "*" is not an array.` everytime i tried to add a repo to patronus.
